### PR TITLE
Split IP Forwarding and NAT into two options

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,6 +49,7 @@ class TestVlanApp(unittest.TestCase):
             "id": 40,
             "cidr": "192.168.40.1/24",
             "dhcp": True,
+            "forwarding": True,
             "nat": False
         }
         response = self.app.post('/api/vlans', json=data)

--- a/tests/test_vlan_manager.py
+++ b/tests/test_vlan_manager.py
@@ -43,6 +43,7 @@ class TestVlanManager(unittest.TestCase):
             "id": 10,
             "cidr": "192.168.10.1/24",
             "dhcp": True,
+            "forwarding": True,
             "nat": True
         }
         self.manager.add_vlan(vlan)
@@ -68,6 +69,7 @@ class TestVlanManager(unittest.TestCase):
             "id": 20,
             "cidr": "10.0.0.1/24",
             "dhcp": False,
+            "forwarding": False,
             "nat": True
         }
         self.manager.add_vlan(vlan)
@@ -87,7 +89,8 @@ class TestVlanManager(unittest.TestCase):
             content = f.read()
             self.assertIn('Address=10.0.0.1/24', content)
             self.assertIn('DHCPServer=no', content)
-            self.assertIn('IPMasquerade=no', content)
+            self.assertIn('IPMasquerade=yes', content)
+            self.assertIn('IPForward=no', content)
 
         # Should detect '25-my-bridge.network' as parent config
         dropin_path = os.path.join(Config.NETWORK_DIR, '25-my-bridge.network.d', 'vlan-20.conf')
@@ -101,6 +104,7 @@ class TestVlanManager(unittest.TestCase):
             "id": 30,
             "cidr": "172.16.0.1/24",
             "dhcp": True,
+            "forwarding": True,
             "nat": True
         }
         self.manager.add_vlan(vlan)

--- a/vlan_manager/app/app.py
+++ b/vlan_manager/app/app.py
@@ -60,6 +60,7 @@ def add_vlan():
     try:
         if not request.is_json:
              data['dhcp'] = 'dhcp' in request.form
+             data['forwarding'] = 'forwarding' in request.form
              data['nat'] = 'nat' in request.form
 
         vlan_manager.add_vlan(data)

--- a/vlan_manager/app/templates/dashboard.html
+++ b/vlan_manager/app/templates/dashboard.html
@@ -56,7 +56,8 @@
                     <th>ID</th>
                     <th>Subnet (CIDR)</th>
                     <th>DHCP</th>
-                    <th>NAT/Fwd</th>
+                    <th>Forwarding</th>
+                    <th>NAT</th>
                     <th>Action</th>
                 </tr>
             </thead>
@@ -66,6 +67,7 @@
                     <td>{{ vlan.id }}</td>
                     <td>{{ vlan.cidr }}</td>
                     <td>{{ 'Enabled' if vlan.dhcp else 'Disabled' }}</td>
+                    <td>{{ 'Enabled' if vlan.get('forwarding', True) else 'Disabled' }}</td>
                     <td>{{ 'Enabled' if vlan.nat else 'Disabled' }}</td>
                     <td>
                         <form action="{{ url_for('delete_vlan', vlan_id=vlan.id) }}" method="POST" onsubmit="return confirm('Are you sure you want to delete VLAN {{ vlan.id }}?');">
@@ -97,7 +99,12 @@
                 </div>
                 <div class="form-group">
                     <label class="checkbox-label">
-                        <input type="checkbox" name="nat"> Enable NAT (Masquerade) & IP Forwarding
+                        <input type="checkbox" name="forwarding"> Enable IP Forwarding
+                    </label>
+                </div>
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" name="nat"> Enable NAT (Masquerade)
                     </label>
                 </div>
                 <button type="submit" class="btn btn-primary">Add VLAN</button>

--- a/vlan_manager/core.py
+++ b/vlan_manager/core.py
@@ -76,6 +76,7 @@ class VlanManager:
 
         vlan_data['id'] = v_id
         vlan_data['dhcp'] = bool(vlan_data.get('dhcp'))
+        vlan_data['forwarding'] = bool(vlan_data.get('forwarding'))
         vlan_data['nat'] = bool(vlan_data.get('nat'))
 
         # Check for overlaps
@@ -120,8 +121,8 @@ Name={name}
 [Network]
 Address={vlan['cidr']}
 DHCPServer={'yes' if vlan.get('dhcp') else 'no'}
-IPMasquerade=no
-IPForward=yes
+IPMasquerade={'yes' if vlan.get('nat') else 'no'}
+IPForward={'yes' if vlan.get('forwarding', True) else 'no'}
 """
             with open(os.path.join(network_dir, f"20-{name}.network"), 'w') as f:
                 f.write(network_content)


### PR DESCRIPTION
This change splits the previously combined IP Forwarding and NAT settings into two independent options for each VLAN. 

Key changes:
- In `vlan_manager/core.py`, the `add_vlan` method now accepts a `forwarding` field.
- The `generate_systemd_config` method now uses the `forwarding` toggle to set `IPForward` and the `nat` toggle to set `IPMasquerade` in the `.network` files.
- The `generate_nftables_config` method remains focused on the `nat` setting for its rules.
- The web interface (`dashboard.html` and `app.py`) has been updated to provide separate checkboxes for these options and display them as separate columns in the VLAN table.
- All tests have been updated to reflect these changes and pass successfully.

Fixes #5

---
*PR created automatically by Jules for task [7880560220546372415](https://jules.google.com/task/7880560220546372415) started by @FelBell*